### PR TITLE
updated integrate annotation and report

### DIFF
--- a/R/liger_preprocess.R
+++ b/R/liger_preprocess.R
@@ -88,6 +88,7 @@ liger_preprocess <- function(sce,
   manifests <- unique(sce@colData[, unique_id_var])
   for (mnft in manifests) {
     dataset_name <- paste0("dataset_", mnft)
+    cli::cli_text("Extracting {.val {dataset_name}}")
     dataset_list[[dataset_name]] <-
       sce[, sce[[unique_id_var]] == mnft]
     mat_list[[dataset_name]] <-

--- a/R/report_integrated_sce.R
+++ b/R/report_integrated_sce.R
@@ -44,14 +44,14 @@ report_integrated_sce <- function(sce,
       "rmarkdown/templates/integrate/skeleton/skeleton.Rmd",
       package = "scFlow"),
     params = list(
-      metadata_path = metadata_tmp_path,
-      categorical_covariates = categorical_covariates
-    ),
-    output_dir = report_folder_path,
-    output_file = report_file,
-    knit_root_dir = krd,
-    intermediates_dir = intd,
-    quiet = TRUE
+                      metadata_path = metadata_tmp_path,
+                      categorical_covariates = categorical_covariates
+                    ),
+                    output_dir = report_folder_path,
+                    output_file = report_file,
+                    knit_root_dir = krd,
+                    intermediates_dir = intd,
+                    quiet = TRUE
   )
   cli::cli_text(c(
     "Report successfully generated: ",

--- a/inst/rmarkdown/templates/integrate/skeleton/categorical_covariates_2.Rmd
+++ b/inst/rmarkdown/templates/integrate/skeleton/categorical_covariates_2.Rmd
@@ -1,0 +1,20 @@
+## `r variable`
+
+<div class = "row">
+<div class="col-md-6">
+<div class = "basicfig">
+```{r, fig.align="center", fig.width=4.5, fig.height=4, fig.cap = sprintf("<b>Proportional barplot by %s</b>", variable)}
+knitr::opts_chunk$set(echo = FALSE)
+metadata$dataset_integration$clustering_plots$pca_proportional_barplots[[variable]]
+```
+</div>
+</div>
+<div class="col-md-6">
+<div class = "basicfig">
+```{r, fig.align="center", fig.width=4.5, fig.height=4, fig.cap = sprintf("<b>Proportional barplot (LIGER) by %s</b>", variable)}
+knitr::opts_chunk$set(echo = FALSE)
+metadata$dataset_integration$clustering_plots$liger_proportional_barplots[[variable]]
+```
+</div>
+</div>
+</div>

--- a/inst/rmarkdown/templates/integrate/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/integrate/skeleton/skeleton.Rmd
@@ -99,7 +99,24 @@ paste(out, collapse='\n')
 
 ```{r conditional_clustering_block, child='clustering.Rmd', eval = !is.null(metadata$cluster_params)}
 ```
+</div>
+</div>
+```{r, results='asis', include=FALSE, echo=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
 
+show_plot <- function(plot_object) {
+  div(style="margin:auto;text-align:center", plot_object)
+}
+
+out <- NULL
+for (variable in names(metadata$dataset_integration$clustering_plots$liger_proportional_barplots)) {
+    out <- c(out, knitr::knit_child("categorical_covariates_2.Rmd"))
+}
+paste(out, collapse='\n')
+```
+`r paste(out, collapse='\n')`
+</div>
+</div>
 # References {-}
 <div id="refs"></div>
 


### PR DESCRIPTION
Updates include:

- added Sankey plot (riverplot) feature to the integrate report (#144)
- added proportional barplot feature to the integrate report showing what percentage of each cluster comes from each group variable (#144)
- fixed issue #142. Labels in clustering plots generated by `annotate_integrated_sce()` now reflect the correct reduction_method used in `cluster_sce() `
- minor updates to `liger_preprocess()`

List of file changes:

```
modified:   R/annotate_integrated_sce.R
modified:   R/liger_preprocess.R
modified:   R/report_integrated_sce.R
new file:   inst/rmarkdown/templates/integrate/skeleton/categorical_covariates_2.Rmd
modified:   inst/rmarkdown/templates/integrate/skeleton/skeleton.Rmd
```