### PR TITLE
feat: add option to test higher pc_mito tail

### DIFF
--- a/R/annotate_sce.R
+++ b/R/annotate_sce.R
@@ -44,6 +44,9 @@
 #' @param max_features the maximum number of features per cell or "adaptive"
 #' @param max_mito the maximum proportion of counts mapping to
 #'   mitochondrial genes (0 - 1) or "adaptive"
+#' @param type_mito see [scater::isOutlier()]. By default, both ends of the
+#'   distribution of mitochondrial content will be tested for outliers. If using
+#'   single-nucleus RNA-sequencing data, consider setting this to "higher".
 #' @param min_ribo the minimum proportion of counts mapping to
 #'   ribosomal genes (0 - 1)
 #' @param max_ribo the maximum proportion of counts mapping to
@@ -79,6 +82,7 @@ annotate_sce <- function(sce,
                          min_features = 100,
                          max_features = "adaptive",
                          max_mito = "adaptive",
+                         type_mito = "both",
                          min_ribo = 0.00,
                          max_ribo = 1.00,
                          min_counts = 2,
@@ -135,6 +139,7 @@ annotate_sce <- function(sce,
       min_features = min_features,
       max_features = max_features,
       max_mito = max_mito,
+      type_mito = type_mito,
       min_ribo = min_ribo,
       max_ribo = max_ribo,
       min_counts = min_counts,

--- a/R/annotate_sce_cells.R
+++ b/R/annotate_sce_cells.R
@@ -13,6 +13,8 @@
 #'   number of genes with >0 counts)
 #' max_mito the maximum proportion of counts mapping to
 #'   mitochondrial genes (0 - 1)
+#' type_mito choice indicating whether outliers in pc_mito should be looked for
+#'   at both tails, or only at the lower/higher end
 #' min_ribo
 #' max_ribo the maximum proportion of counts mapping to
 #'   ribosomal genes (0 - 1)
@@ -86,7 +88,7 @@ annotate_sce_cells <- function(sce, ...) {
       sce$pc_mito,
       nmads = args$nmads,
       subset = sce$qc_metric_passed,
-      type = "both",
+      type = args$type_mito,
       log = FALSE)
     higher <-
       as.numeric(attributes(outliers)$thresholds["higher"]) #not int for pcmito

--- a/man/annotate_sce.Rd
+++ b/man/annotate_sce.Rd
@@ -11,6 +11,7 @@ annotate_sce(
   min_features = 100,
   max_features = "adaptive",
   max_mito = "adaptive",
+  type_mito = "both",
   min_ribo = 0,
   max_ribo = 1,
   min_counts = 2,
@@ -39,6 +40,10 @@ number of genes with >0 counts)}
 
 \item{max_mito}{the maximum proportion of counts mapping to
 mitochondrial genes (0 - 1) or "adaptive"}
+
+\item{type_mito}{see \code{\link[scater:reexports]{scater::isOutlier()}}. By default, both ends of the
+distribution of mitochondrial content will be tested for outliers. If using
+single-nucleus RNA-sequencing data, consider setting this to "higher".}
 
 \item{min_ribo}{the minimum proportion of counts mapping to
 ribosomal genes (0 - 1)}

--- a/man/annotate_sce_cells.Rd
+++ b/man/annotate_sce_cells.Rd
@@ -16,6 +16,8 @@ min_features the minimum number of features per cell (i.e. the minimum
 number of genes with >0 counts)
 max_mito the maximum proportion of counts mapping to
 mitochondrial genes (0 - 1)
+type_mito choice indicating whether outliers in pc_mito should be looked for
+at both tails, or only at the lower/higher end
 min_ribo
 max_ribo the maximum proportion of counts mapping to
 ribosomal genes (0 - 1)


### PR DESCRIPTION
For QC of single-nucleus RNA-sequencing, only need to look for outliers
in the higher tail of mitochondrial counts, as good quality nuclei
should not contain any mitochondrial transcripts. Thus, added an
option to allow users to specify this in `annotate_sce()`.
Resolves https://github.com/combiz/scFlow/issues/187